### PR TITLE
[FIX] : 여행계획 좌표 데이터 및 날씨 API 개선

### DIFF
--- a/plans/serializers.py
+++ b/plans/serializers.py
@@ -4,28 +4,26 @@ from places.models import Place
 
 
 class TravelPlanListSerializer(serializers.ModelSerializer):
-    """여행 계획 목록용 시리얼라이저"""
     title = serializers.SerializerMethodField()
     description = serializers.SerializerMethodField()
     region_id = serializers.SerializerMethodField()
+    start_date = serializers.SerializerMethodField()
+    end_date = serializers.SerializerMethodField()
 
     class Meta:
         model = TravelPlan
         fields = ["id", "region_id", "title", "description", "subregion_id",
-                  "created_at", "updated_at"]
+                  "start_date", "end_date", "created_at", "updated_at"]
 
     def get_title(self, obj):
-        """요청 언어에 맞는 제목 반환"""
         lang = self.context.get("lang", "ko")
         return obj.get_title(lang)
 
     def get_description(self, obj):
-        """요청 언어에 맞는 설명 반환"""
         lang = self.context.get("lang", "ko")
         return obj.get_description(lang)
 
     def get_region_id(self, obj):
-        """subregion_id로부터 region_id 동적 계산"""
         if obj.subregion_id:
             try:
                 from regions.models import SubRegion
@@ -35,9 +33,40 @@ class TravelPlanListSerializer(serializers.ModelSerializer):
                 pass
         return None
 
+    def get_start_date(self, obj):
+        # DB 필드에 값이 있으면 우선 사용
+        if obj.start_date:
+            return obj.start_date
+
+        # 관광지 방문일 기준으로 계산
+        plan_places = obj.plan_places.all()
+        if not plan_places.exists():
+            return None
+
+        dates = [pp.visit_date for pp in plan_places if pp.visit_date]
+        if not dates:
+            return None
+
+        return min(dates)
+
+    def get_end_date(self, obj):
+        # DB 필드에 값이 있으면 우선 사용
+        if obj.end_date:
+            return obj.end_date
+
+        # 관광지 방문일 기준으로 계산
+        plan_places = obj.plan_places.all()
+        if not plan_places.exists():
+            return None
+
+        dates = [pp.visit_date for pp in plan_places if pp.visit_date]
+        if not dates:
+            return None
+
+        return max(dates)
+
 
 class PlaceDetailSerializer(serializers.Serializer):
-    """관광지 상세 정보 시리얼라이저"""
     id = serializers.IntegerField()
     category_id = serializers.IntegerField()
     subcategory_id = serializers.IntegerField()
@@ -55,19 +84,21 @@ class PlaceDetailSerializer(serializers.Serializer):
     updated_at = serializers.DateTimeField()
 
     def to_representation(self, instance):
-        """Place 모델 인스턴스를 API 형태로 변환"""
         if isinstance(instance, Place):
             lang = self.context.get("lang", "ko")
+
+            # GIS PointField에서 위도/경도 추출
+            latitude = instance.latitude
+            longitude = instance.longitude
+
             return {
                 "id": instance.id,
                 "category_id": getattr(instance, 'category_id', None),
                 "subcategory_id": getattr(instance, 'sub_category_id', None),
-                "region_id": getattr(instance, 'region_id', None) or (
-                    instance.region.id if hasattr(instance, 'region') else None),
-                "subregion_id": getattr(instance, 'subregion_id', None) or (
-                    instance.subregion.id if hasattr(instance, 'subregion') else None),
-                "latitude": getattr(instance, 'latitude', None),
-                "longitude": getattr(instance, 'longitude', None),
+                "region_id": self._get_region_id(instance),
+                "subregion_id": self._get_subregion_id(instance),
+                "latitude": latitude,
+                "longitude": longitude,
                 "phone_number": getattr(instance, 'phone_number', ""),
                 "use_time": getattr(instance, 'use_time', ""),
                 "image_url": getattr(instance, 'image_url', ""),
@@ -79,9 +110,22 @@ class PlaceDetailSerializer(serializers.Serializer):
             }
         return super().to_representation(instance)
 
+    def _get_region_id(self, instance):
+        if hasattr(instance, 'region') and instance.region:
+            return instance.region.id
+        if hasattr(instance, 'region_id') and instance.region_id:
+            return instance.region_id
+        return None
+
+    def _get_subregion_id(self, instance):
+        if hasattr(instance, 'sub_region') and instance.sub_region:
+            return instance.sub_region.id
+        if hasattr(instance, 'sub_region_id') and instance.sub_region_id:
+            return instance.sub_region_id
+        return None
+
 
 class PlanPlaceDetailSerializer(serializers.ModelSerializer):
-    """여행 계획 관광지 상세 시리얼라이저"""
     place = serializers.SerializerMethodField()
 
     class Meta:
@@ -89,7 +133,6 @@ class PlanPlaceDetailSerializer(serializers.ModelSerializer):
         fields = ["id", "place", "visit_date", "visit_time", "created_at", "updated_at"]
 
     def get_place(self, obj):
-        """관광지 상세 정보 반환"""
         try:
             place = Place.objects.get(id=obj.place_id)
             serializer = PlaceDetailSerializer(place, context=self.context)
@@ -99,29 +142,35 @@ class PlanPlaceDetailSerializer(serializers.ModelSerializer):
 
 
 class TravelPlanDetailSerializer(serializers.ModelSerializer):
-    """여행 계획 상세 시리얼라이저"""
     title = serializers.SerializerMethodField()
     description = serializers.SerializerMethodField()
     region_id = serializers.SerializerMethodField()
     plan_places = PlanPlaceDetailSerializer(many=True, read_only=True)
+    schedule_by_date = serializers.SerializerMethodField()
 
     class Meta:
         model = TravelPlan
         fields = ["id", "title", "description", "region_id", "subregion_id", "start_date", "end_date",
-                  "plan_places", "created_at", "updated_at"]
+                  "plan_places", "schedule_by_date", "created_at", "updated_at"]
 
     def get_title(self, obj):
-        """요청 언어에 맞는 제목 반환"""
         lang = self.context.get("lang", "ko")
         return obj.get_title(lang)
 
     def get_description(self, obj):
-        """요청 언어에 맞는 설명 반환"""
         lang = self.context.get("lang", "ko")
         return obj.get_description(lang)
 
     def get_region_id(self, obj):
-        """첫 번째 관광지의 region_id 반환"""
+        if obj.subregion_id:
+            try:
+                from regions.models import SubRegion
+                subregion = SubRegion.objects.select_related("region").get(id=obj.subregion_id)
+                return subregion.region.id
+            except SubRegion.DoesNotExist:
+                pass
+
+        # fallback: 첫 번째 관광지의 region_id
         first_plan_place = obj.plan_places.first()
         if first_plan_place:
             try:
@@ -132,15 +181,62 @@ class TravelPlanDetailSerializer(serializers.ModelSerializer):
                 pass
         return None
 
+    def get_schedule_by_date(self, obj):
+        from datetime import datetime, timedelta
+
+        time_slots = ["09:00", "11:00", "13:00", "15:00", "17:00", "19:00", "21:00", "23:00"]
+        schedule_by_date = {}
+
+        if obj.start_date and obj.end_date:
+            # 날짜가 설정된 경우: 설정된 기간의 모든 날짜
+            current_date = obj.start_date
+            while current_date <= obj.end_date:
+                date_str = current_date.strftime("%Y-%m-%d")
+                schedule_by_date[date_str] = {slot: None for slot in time_slots}
+                current_date += timedelta(days=1)
+        else:
+            # 날짜가 설정 안 된 경우: 오늘 날짜 하루만 기본 표시
+            today = datetime.now().date()
+            date_str = today.strftime("%Y-%m-%d")
+            schedule_by_date[date_str] = {slot: None for slot in time_slots}
+
+        # 실제 관광지 데이터가 있는 경우 처리
+        plan_places = obj.plan_places.all()
+        for plan_place in plan_places:
+            date_str = plan_place.visit_date.strftime("%Y-%m-%d")
+
+            # 날짜가 처음 나오면 빈 슬롯 구조 생성 (예외 케이스)
+            if date_str not in schedule_by_date:
+                schedule_by_date[date_str] = {slot: None for slot in time_slots}
+
+            time_str = plan_place.visit_time.strftime("%H:%M") if plan_place.visit_time else None
+
+            # 고정 슬롯에 맞는 시간이면 데이터 추가
+            if time_str in time_slots:
+                try:
+                    place = Place.objects.get(id=plan_place.place_id)
+                    place_serializer = PlaceDetailSerializer(place, context=self.context)
+                    place_data = place_serializer.data
+                except Place.DoesNotExist:
+                    place_data = None
+
+                schedule_by_date[date_str][time_str] = {
+                    "id": plan_place.id,
+                    "place": place_data
+                }
+
+        return schedule_by_date
+
 
 class TravelPlanCreateSerializer(serializers.Serializer):
-    """여행 계획 생성용 시리얼라이저"""
     name = serializers.CharField(max_length=200)
     description = serializers.CharField(allow_blank=True, required=False)
     subregion_id = serializers.IntegerField()
 
     def create(self, validated_data):
-        """여행 계획 생성"""
+        # lang 파라미터 분리 (사용자가 입력한 언어)
+        input_lang = validated_data.pop("lang", "ko")
+
         translation_data = {
             "title": validated_data.pop("name"),
             "description": validated_data.pop("description", ""),
@@ -149,22 +245,98 @@ class TravelPlanCreateSerializer(serializers.Serializer):
         # TravelPlan 생성
         travel_plan = TravelPlan.objects.create(**validated_data)
 
-        # 한국어 번역 생성
-        TravelPlanTranslation.objects.create(
-            travel_plan=travel_plan,
-            lang="ko",
-            **translation_data
-        )
+        # 지원하는 모든 언어로 번역 생성
+        supported_languages = ["ko", "en", "jp", "cn"]
+
+        for lang in supported_languages:
+            if lang == input_lang:
+                # 사용자가 입력한 언어는 실제 데이터 사용
+                TravelPlanTranslation.objects.create(
+                    travel_plan=travel_plan,
+                    lang=lang,
+                    **translation_data
+                )
+            else:
+                # 다른 언어는 빈 값으로 생성 (나중에 번역 추가 예정)
+                TravelPlanTranslation.objects.create(
+                    travel_plan=travel_plan,
+                    lang=lang,
+                    title=f"[{lang.upper()}] {translation_data['title']}",  # 임시 표시
+                    description=""
+                )
 
         return travel_plan
 
+
 class PlanPlaceCreateSerializer(serializers.Serializer):
-    """계획 관광지 생성용 시리얼라이저"""
     place_id = serializers.IntegerField()
     visit_date = serializers.DateField()
     visit_time = serializers.TimeField()
 
+    def validate_visit_time(self, value):
+        allowed_times = ["09:00", "11:00", "13:00", "15:00", "17:00", "19:00", "21:00", "23:00"]
+        time_str = value.strftime("%H:%M")
+
+        if time_str not in allowed_times:
+            raise serializers.ValidationError(
+                f"시간은 다음 중 하나여야 합니다: {', '.join(allowed_times)}"
+            )
+        return value
+
 
 class PlanPlaceListCreateSerializer(serializers.Serializer):
-    """계획 관광지 목록 생성용 시리얼라이저"""
     places = PlanPlaceCreateSerializer(many=True)
+
+
+class TravelPlanUpdateSerializer(serializers.Serializer):
+    title = serializers.CharField(max_length=200, required=False)
+    description = serializers.CharField(allow_blank=True, required=False)
+    start_date = serializers.DateField(required=False)
+    end_date = serializers.DateField(required=False)
+    places = PlanPlaceCreateSerializer(many=True, required=False)
+
+    def validate(self, data):
+        start_date = data.get('start_date')
+        end_date = data.get('end_date')
+
+        if start_date and end_date and start_date > end_date:
+            raise serializers.ValidationError("시작일은 종료일보다 이전이어야 합니다")
+
+        return data
+
+    def update(self, instance, validated_data):
+        places_data = validated_data.pop('places', None)
+        lang = self.context.get('lang', 'ko')
+
+        # 기본 정보 업데이트
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        instance.save()
+
+        # 제목/설명 번역 업데이트
+        title = validated_data.get('title')
+        description = validated_data.get('description')
+
+        if title or description:
+            translation, created = TravelPlanTranslation.objects.get_or_create(
+                travel_plan=instance,
+                lang=lang,
+                defaults={'title': title or '', 'description': description or ''}
+            )
+            if not created:
+                if title:
+                    translation.title = title
+                if description:
+                    translation.description = description
+                translation.save()
+
+        # 관광지 일정 업데이트
+        if places_data is not None:
+            PlanPlace.objects.filter(travel_plan=instance).delete()
+            for place_data in places_data:
+                PlanPlace.objects.create(
+                    travel_plan=instance,
+                    **place_data
+                )
+
+        return instance

--- a/plans/views.py
+++ b/plans/views.py
@@ -11,7 +11,7 @@ from plans.serializers import (
     TravelPlanListSerializer,
     TravelPlanDetailSerializer,
     TravelPlanCreateSerializer,
-    PlanPlaceListCreateSerializer
+    PlanPlaceListCreateSerializer, TravelPlanUpdateSerializer
 )
 
 
@@ -411,37 +411,138 @@ def plan_list_create(request):
             )
         )
     },
-    tags=["여행계획"]
+    tags=["여행일정"]
+)
+
+@swagger_auto_schema(
+   method="post",
+   operation_summary="여행 일정 관광지 추가",
+   operation_description="여행 계획에 관광지들을 추가합니다.",
+   request_body=openapi.Schema(
+       type=openapi.TYPE_OBJECT,
+       required=["places"],
+       properties={
+           "places": openapi.Schema(
+               type=openapi.TYPE_ARRAY,
+               example=[
+                   # 9월 7일
+                   {"place_id": None, "visit_date": "2025-09-07", "visit_time": "09:00"},
+                   {"place_id": None, "visit_date": "2025-09-07", "visit_time": "11:00"},
+                   {"place_id": None, "visit_date": "2025-09-07", "visit_time": "13:00"},
+                   {"place_id": None, "visit_date": "2025-09-07", "visit_time": "15:00"},
+                   {"place_id": None, "visit_date": "2025-09-07", "visit_time": "17:00"},
+                   {"place_id": None, "visit_date": "2025-09-07", "visit_time": "19:00"},
+                   {"place_id": None, "visit_date": "2025-09-07", "visit_time": "21:00"},
+                   {"place_id": None, "visit_date": "2025-09-07", "visit_time": "23:00"},
+                   # 9월 8일
+                   {"place_id": None, "visit_date": "2025-09-08", "visit_time": "09:00"},
+                   {"place_id": None, "visit_date": "2025-09-08", "visit_time": "11:00"},
+                   {"place_id": None, "visit_date": "2025-09-08", "visit_time": "13:00"},
+                   {"place_id": None, "visit_date": "2025-09-08", "visit_time": "15:00"},
+                   {"place_id": None, "visit_date": "2025-09-08", "visit_time": "17:00"},
+                   {"place_id": None, "visit_date": "2025-09-08", "visit_time": "19:00"},
+                   {"place_id": None, "visit_date": "2025-09-08", "visit_time": "21:00"},
+                   {"place_id": None, "visit_date": "2025-09-08", "visit_time": "23:00"},
+                   # 9월 9일
+                   {"place_id": None, "visit_date": "2025-09-09", "visit_time": "09:00"},
+                   {"place_id": None, "visit_date": "2025-09-09", "visit_time": "11:00"},
+                   {"place_id": None, "visit_date": "2025-09-09", "visit_time": "13:00"},
+                   {"place_id": None, "visit_date": "2025-09-09", "visit_time": "15:00"},
+                   {"place_id": None, "visit_date": "2025-09-09", "visit_time": "17:00"},
+                   {"place_id": None, "visit_date": "2025-09-09", "visit_time": "19:00"},
+                   {"place_id": None, "visit_date": "2025-09-09", "visit_time": "21:00"},
+                   {"place_id": None, "visit_date": "2025-09-09", "visit_time": "23:00"}
+               ],
+               items=openapi.Schema(
+                   type=openapi.TYPE_OBJECT,
+                   required=["place_id", "visit_date", "visit_time"],
+                   properties={
+                       "place_id": openapi.Schema(type=openapi.TYPE_INTEGER, description="관광지 ID", example=5690),
+                       "visit_date": openapi.Schema(type=openapi.TYPE_STRING, description="방문일", example="2025-09-07"),
+                       "visit_time": openapi.Schema(
+                           type=openapi.TYPE_STRING,
+                           description="방문시간",
+                           example="09:00",
+                           enum=["09:00", "11:00", "13:00", "15:00", "17:00", "19:00", "21:00", "23:00"]
+                       ),
+                   }
+               )
+           )
+       }
+   ),
+   responses={
+       201: openapi.Response(description="추가 성공"),
+       400: openapi.Response(description="잘못된 요청")
+   },
+   tags=["여행일정"]
 )
 @swagger_auto_schema(
-    methods=["post", "patch"],
-    operation_summary="여행 일정 관광지 추가/수정",
-    operation_description="여행 계획에 관광지들을 추가하거나 수정합니다.",
-    request_body=openapi.Schema(
-        type=openapi.TYPE_OBJECT,
-        required=["places"],
-        properties={
-            "places": openapi.Schema(
-                type=openapi.TYPE_ARRAY,
-                items=openapi.Schema(
-                    type=openapi.TYPE_OBJECT,
-                    required=["place_id", "visit_date", "visit_time"],
-                    properties={
-                        "place_id": openapi.Schema(type=openapi.TYPE_INTEGER, description="관광지 ID", example=1),
-                        "visit_date": openapi.Schema(type=openapi.TYPE_STRING, description="방문일", example="2025-07-05"),
-                        "visit_time": openapi.Schema(type=openapi.TYPE_STRING, description="방문시간", example="09:00"),
-                    }
-                )
-            )
-        }
-    ),
-    responses={
-        200: openapi.Response(description="수정 성공"),
-        201: openapi.Response(description="추가 성공"),
-        400: openapi.Response(description="잘못된 요청")
-    },
-    tags=["여행계획"]
+   method="patch",
+   operation_summary="여행 계획 전체 수정",
+   operation_description="여행 계획의 제목, 설명, 날짜, 관광지 일정을 수정합니다. 모든 필드는 선택사항입니다.",
+   request_body=openapi.Schema(
+       type=openapi.TYPE_OBJECT,
+       properties={
+           "title": openapi.Schema(type=openapi.TYPE_STRING, description="여행 계획 제목", example="새로운 여행 제목"),
+           "description": openapi.Schema(type=openapi.TYPE_STRING, description="여행 설명", example="수정된 여행 설명"),
+           "start_date": openapi.Schema(type=openapi.TYPE_STRING, description="시작일", example="2025-09-07"),
+           "end_date": openapi.Schema(type=openapi.TYPE_STRING, description="종료일", example="2025-09-09"),
+           "places": openapi.Schema(
+               type=openapi.TYPE_ARRAY,
+               description="관광지 일정 (선택사항)",
+               example=[
+                   # 9월 7일
+                   {"place_id": None, "visit_date": "2025-09-07", "visit_time": "09:00"},
+                   {"place_id": None, "visit_date": "2025-09-07", "visit_time": "11:00"},
+                   {"place_id": None, "visit_date": "2025-09-07", "visit_time": "13:00"},
+                   {"place_id": None, "visit_date": "2025-09-07", "visit_time": "15:00"},
+                   {"place_id": None, "visit_date": "2025-09-07", "visit_time": "17:00"},
+                   {"place_id": None, "visit_date": "2025-09-07", "visit_time": "19:00"},
+                   {"place_id": None, "visit_date": "2025-09-07", "visit_time": "21:00"},
+                   {"place_id": None, "visit_date": "2025-09-07", "visit_time": "23:00"},
+                   # 9월 8일
+                   {"place_id": None, "visit_date": "2025-09-08", "visit_time": "09:00"},
+                   {"place_id": None, "visit_date": "2025-09-08", "visit_time": "11:00"},
+                   {"place_id": None, "visit_date": "2025-09-08", "visit_time": "13:00"},
+                   {"place_id": None, "visit_date": "2025-09-08", "visit_time": "15:00"},
+                   {"place_id": None, "visit_date": "2025-09-08", "visit_time": "17:00"},
+                   {"place_id": None, "visit_date": "2025-09-08", "visit_time": "19:00"},
+                   {"place_id": None, "visit_date": "2025-09-08", "visit_time": "21:00"},
+                   {"place_id": None, "visit_date": "2025-09-08", "visit_time": "23:00"},
+                   # 9월 9일
+                   {"place_id": None, "visit_date": "2025-09-09", "visit_time": "09:00"},
+                   {"place_id": None, "visit_date": "2025-09-09", "visit_time": "11:00"},
+                   {"place_id": None, "visit_date": "2025-09-09", "visit_time": "13:00"},
+                   {"place_id": None, "visit_date": "2025-09-09", "visit_time": "15:00"},
+                   {"place_id": None, "visit_date": "2025-09-09", "visit_time": "17:00"},
+                   {"place_id": None, "visit_date": "2025-09-09", "visit_time": "19:00"},
+                   {"place_id": None, "visit_date": "2025-09-09", "visit_time": "21:00"},
+                   {"place_id": None, "visit_date": "2025-09-09", "visit_time": "23:00"}
+               ],
+               items=openapi.Schema(
+                   type=openapi.TYPE_OBJECT,
+                   required=["place_id", "visit_date", "visit_time"],
+                   properties={
+                       "place_id": openapi.Schema(type=openapi.TYPE_INTEGER, description="관광지 ID", example=5690),
+                       "visit_date": openapi.Schema(type=openapi.TYPE_STRING, description="방문일", example="2025-09-07"),
+                       "visit_time": openapi.Schema(
+                           type=openapi.TYPE_STRING,
+                           description="방문시간",
+                           example="11:00",
+                           enum=["09:00", "11:00", "13:00", "15:00", "17:00", "19:00", "21:00", "23:00"]
+                       ),
+                   }
+               )
+           )
+       }
+   ),
+   responses={
+       200: openapi.Response(description="수정 성공"),
+       400: openapi.Response(description="잘못된 요청")
+   },
+   tags=["여행일정"]
 )
+
 @api_view(["GET", "POST", "PATCH"])
 @permission_classes([IsAuthenticated])
 def plan_detail(request, plan_id):
@@ -465,21 +566,78 @@ def plan_detail(request, plan_id):
 
         return Response(response_data, status=status.HTTP_200_OK)
 
-    elif request.method in ["POST", "PATCH"]:
+
+
+    elif request.method == "POST":
+
+        # 기존 관광지 추가 로직 (그대로 유지)
+
         serializer = PlanPlaceListCreateSerializer(data=request.data)
+
         if serializer.is_valid():
+
             PlanPlace.objects.filter(travel_plan=travel_plan).delete()
 
             for place_data in serializer.validated_data["places"]:
                 PlanPlace.objects.create(
+
                     travel_plan=travel_plan,
+
                     place_id=place_data["place_id"],
+
                     visit_date=place_data["visit_date"],
+
                     visit_time=place_data["visit_time"]
+
                 )
 
-            status_code = status.HTTP_201_CREATED if request.method == "POST" else status.HTTP_200_OK
-            return Response(status=status_code)
+            # 업데이트된 전체 데이터 반환
+
+            lang = request.GET.get("lang", "ko")
+
+            detail_serializer = TravelPlanDetailSerializer(travel_plan, context={"lang": lang})
+
+            favorite_places = get_user_favorite_places(request.user.id, lang)
+
+            response_data = detail_serializer.data.copy()
+
+            response_data.update({"favorite_places": favorite_places})
+
+            return Response(response_data, status=status.HTTP_201_CREATED)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+    elif request.method == "PATCH":
+
+        # 새로운 전체 수정 로직
+
+        lang = request.GET.get("lang", "ko")
+
+        serializer = TravelPlanUpdateSerializer(
+
+            travel_plan,
+
+            data=request.data,
+
+            context={"lang": lang}
+
+        )
+
+        if serializer.is_valid():
+            updated_plan = serializer.save()
+
+            # 업데이트된 전체 데이터 반환
+
+            detail_serializer = TravelPlanDetailSerializer(updated_plan, context={"lang": lang})
+
+            favorite_places = get_user_favorite_places(request.user.id, lang)
+
+            response_data = detail_serializer.data.copy()
+
+            response_data.update({"favorite_places": favorite_places})
+
+            return Response(response_data, status=status.HTTP_200_OK)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
@@ -543,7 +701,7 @@ def plan_detail(request, plan_id):
         ),
         404: openapi.Response(description="여행 계획을 찾을 수 없음")
     },
-    tags=["여행계획"]
+    tags=["여행일정"]
 )
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])

--- a/weather/serializers.py
+++ b/weather/serializers.py
@@ -63,7 +63,7 @@ class WeatherResponseSerializer(serializers.Serializer):
     current_weather = CurrentWeatherSerializer(help_text="현재 날씨 정보")
     tomorrow_weather = TomorrowWeatherSerializer(help_text="내일 날씨 정보")
     detail_info = DetailInfoSerializer(help_text="상세 날씨 정보")
-    hourly_forecast = HourlyForecastItemSerializer(many=True, help_text="시간별 예보 (12시간)")
+    hourly_forecast = HourlyForecastItemSerializer(many=True, help_text="시간별 예보 (24시간)")
     air_quality = AirQualityDetailSerializer(help_text="대기질 상세 정보")
     travel_tip = TravelTipSerializer(help_text="여행 팁")
     location_name = serializers.CharField(help_text="지역명")

--- a/weather/views.py
+++ b/weather/views.py
@@ -105,7 +105,7 @@ class WeatherBaseView:
         except Exception as e:
             return "+0.0°"
 
-    def _get_hourly_forecast_from_db(self, region_id, sub_region_id=None, hours=15):
+    def _get_hourly_forecast_from_db(self, region_id, sub_region_id=None, hours=24):
         # DB에서 현재 시간부터 15시간 예보 데이터 조회
         now = timezone.now()
         # 현재 시간이 07:49라면 08:00부터 시작 (다음 정시)
@@ -312,7 +312,7 @@ class WeatherAPI(APIView, WeatherBaseView):
                 }, status=status.HTTP_404_NOT_FOUND)
 
             # 시간별 예보 데이터 조회 (현재 시간부터 15시간)
-            hourly_forecast = self._get_hourly_forecast_from_db(region_id, hours=15)
+            hourly_forecast = self._get_hourly_forecast_from_db(region_id, hours=24)
 
         except Region.DoesNotExist:
             return Response({
@@ -369,7 +369,7 @@ class WeatherAPI(APIView, WeatherBaseView):
                 }, status=status.HTTP_404_NOT_FOUND)
 
             # 시간별 예보 데이터 조회 (현재 시간부터 15시간)
-            hourly_forecast = self._get_hourly_forecast_from_db(region_id, subregion_id, hours=15)
+            hourly_forecast = self._get_hourly_forecast_from_db(region_id, subregion_id, hours=24)
 
         except Region.DoesNotExist:
             return Response({


### PR DESCRIPTION
- 날씨 API: 시간별 예보 15시간 → 24시간 확장
- Swagger 문서: 여행계획/여행일정 태그 분리 완료
- 여행계획 좌표: GIS PointField를 latitude/longitude로 변환하여 지도 표시 지원
- 여행계획 날짜: 관광지 방문일 기반 start_date/end_date 자동 계산
- 고정 시간대: 9-23시 2시간 간격 8개 슬롯 구현 및 검증 추가

## PR Checklist
아래 요구사항을 만족하는지 체크:

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [x] 작성한 코드 문서화 (기능 추가 / 버그 개선)

## PR Type
해당 PR이 포함하는 내용 체크:

- [ ] 패키지
  - [ ] 패키지 추가
  - [ ] 패키지 설정 변경
- [ ] CI
  - [ ] CI 구성 추가
  - [ ] CI 설정 변경
- [ ] 문서화
  - [ ] 신규 문서 추가
  - [x] 기존 문서 변경
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 코드 개선
  - [x] 성능 개선
  - [ ] UI 개선
  - [ ] 성능에 영향을 끼치지 않는 수정
- [ ] 테스트
  - [ ] 테스트 코드 추가
  - [ ] 기존 테스트 코드 변경
- [ ] 커밋 되돌리기
- [ ] 기타

## 해당 PR에 대한 설명

## 스크린샷

## 기타 정보
