### PR TITLE
[FIX] : K-POP 서브카테고리 필터링 로직 수정

### DIFF
--- a/places/views.py
+++ b/places/views.py
@@ -954,11 +954,18 @@ class PlacesBySubCategoryIdAPIView(APIView):
         subregion_id = request.query_params.get("subregion_id")
 
         from categories.models import SubCategory
-        get_object_or_404(SubCategory, id=subcategory_id)
+        subcategory = get_object_or_404(SubCategory, id=subcategory_id)
 
-        # 기본 쿼리: 서브카테고리별 필터링
-        queryset = Place.objects.filter(sub_category_id=subcategory_id)
+        # K-POP 서브카테고리인지 확인
+        is_kpop_subcategory = (subcategory.category.id == settings.KPOP_CATEGORY_ID)
 
+        # K-POP 서브카테고리면 is_kpop_spot으로 검색
+        if is_kpop_subcategory:
+            # K-POP은 is_kpop_spot=True인 모든 장소 (원래 카테고리 유지)
+            queryset = Place.objects.filter(is_kpop_spot=True)
+        else:
+            # 다른 카테고리는 기존대로 sub_category_id로 검색
+            queryset = Place.objects.filter(sub_category_id=subcategory_id)
         # 지역 필터링 적용
         if region_id:
             queryset = queryset.filter(region_id=region_id)


### PR DESCRIPTION
- K-POP 서브카테고리 선택 시 is_kpop_spot으로 검색
- 원래 카테고리(역사, 미술관 등) 유지하면서 K-POP 명소로도 표시
- K-POP 장소가 여러 카테고리에 동시 표시 가능

## PR Checklist
아래 요구사항을 만족하는지 체크:

- [ ] 작성한 코드에 대한 테스트 코드 작성 (기능 추가 / 버그 개선)
- [x] 작성한 코드 문서화 (기능 추가 / 버그 개선)

## PR Type
해당 PR이 포함하는 내용 체크:

- [ ] 패키지
  - [ ] 패키지 추가
  - [ ] 패키지 설정 변경
- [ ] CI
  - [ ] CI 구성 추가
  - [ ] CI 설정 변경
- [x] 문서화
  - [ ] 신규 문서 추가
  - [x] 기존 문서 변경
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 코드 개선
  - [x] 성능 개선
  - [ ] UI 개선
  - [ ] 성능에 영향을 끼치지 않는 수정
- [ ] 테스트
  - [ ] 테스트 코드 추가
  - [ ] 기존 테스트 코드 변경
- [ ] 커밋 되돌리기
- [ ] 기타

## 해당 PR에 대한 설명

- k-pop만 안뜨는 문제 해결

## 스크린샷
<img width="857" height="566" alt="스크린샷 2025-10-25 오전 2 13 20" src="https://github.com/user-attachments/assets/21206121-e1cb-497c-abba-5b1c6b762294" />


## 기타 정보
